### PR TITLE
UPDATE package.json with latest simple-web-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mousetrap": "^1.6.1",
     "qr-image": "^3.2.0",
     "rxjs": "^5.5.5",
-    "simple-web-proxy": "^0.1.0",
+    "simple-web-proxy": "^0.2.0",
     "sudo-prompt": "^8.1.0",
     "urlsafe-base64": "^1.0.0",
     "vue": "^2.3.3",


### PR DESCRIPTION
## under  4.18.6-arch1-1-ARCH
Installation was made from `yay -S electron-ssr`
http_proxy on LAN still doesn't works. 
Then I found this issue is cause by `packages.json`

在最新版Arch Linux下http_proxy虽然在log 上是监听了`0.0.0.0` 但是` ss -lntu | grep 12333`发现实际监听的还是`127.0.0.1`，LAN内其它机器也connection refused.后来发现是依赖的缘故。

